### PR TITLE
Fix request id handling

### DIFF
--- a/jsonrpcparts/application.py
+++ b/jsonrpcparts/application.py
@@ -107,7 +107,8 @@ class JSONPRCApplication(JSONPRCCollection):
                     responses.append(ds.assemble_error_response(
                         errors.RPCInternalError(
                             'While processing the follwoing message ("%s","%s","%s") ' % (method, params, request_id) +\
-                            'encountered the following error message "%s"' % ex.message
+                            'encountered the following error message "%s"' % ex.message,
+                            request_id=request_id
                         )
                     ))
 

--- a/jsonrpcparts/serializers.py
+++ b/jsonrpcparts/serializers.py
@@ -7,8 +7,9 @@ This file is part of `jsonrpcparts` project. See project's source for license an
 """
 
 import json
-import time
 import random
+import time
+import uuid
 
 from . import errors
 
@@ -272,15 +273,15 @@ class JSONRPC20Serializer:
             base["params"] = params
 
         if not notification:
-            base['id'] = long(time.time() * 1000)
+            base['id'] = str(uuid.uuid4())
 
         return base
 
     @staticmethod
     def assemble_response(result, request_id):
         return {
-            "jsonrpc": "2.0", 
-            "result": result, 
+            "jsonrpc": "2.0",
+            "result": result,
             "id": request_id
         }
 
@@ -292,21 +293,21 @@ class JSONRPC20Serializer:
 
         if error.error_data is None:
             return {
-                "jsonrpc": "2.0", 
+                "jsonrpc": "2.0",
                 "error": {
-                    "code":error.error_code, 
+                    "code":error.error_code,
                     "message":error.message
-                }, 
+                },
                 "id": error.request_id
             }
         else:
             return {
-                "jsonrpc": "2.0", 
+                "jsonrpc": "2.0",
                 "error": {
-                    "code":error.error_code, 
+                    "code":error.error_code,
                     "message": error.message,
                     "data": error.error_data
-                }, 
+                },
                 "id": error.request_id
             }
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -26,6 +26,9 @@ class JSONPRCApplicationTestSuite(TestCase):
             'adder',
             (4, 3)
         )
+
+        assert request1['id'] != request2['id']
+
         requests, is_batch_mode = JSONRPC20Serializer.parse_request(
             json.dumps([request1, request2])
         )
@@ -36,7 +39,7 @@ class JSONPRCApplicationTestSuite(TestCase):
 
         response_json = responses[0]
         assert 'error' not in response_json
-        assert response_json['id'] == request2['id']
+        assert response_json['id'] == request1['id']
         assert response_json['result'] == 5
 
         response_json = responses[1]
@@ -64,7 +67,7 @@ class JSONPRCApplicationTestSuite(TestCase):
 
         response_json = responses_data[0]
         assert 'error' not in response_json
-        assert response_json['id'] == request2['id']
+        assert response_json['id'] == request1['id']
         assert response_json['result'] == 5
 
         response_json = responses_data[1]

--- a/tests/test_wsgi_application.py
+++ b/tests/test_wsgi_application.py
@@ -75,7 +75,7 @@ class JSONPRCWSGIApplicationTestSuite(TestCase):
 
         response_json = responses_data[0]
         assert 'error' not in response_json
-        assert response_json['id'] == request2['id']
+        assert response_json['id'] == request1['id']
         assert response_json['result'] == 5
 
         response_json = responses_data[1]


### PR DESCRIPTION
Client:
- Fix for occasional duplicate request ID generation when calls were queued up in the same microsecond 

Server (Application)
- Fix request ID echo-ing - was returning Null on some types of rewrapped errors.
